### PR TITLE
Add external URL to feed item summary

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -84,6 +84,17 @@ class Post extends Model implements Feedable, Sluggable, Tweetable
         return CommonMark::convertToHtml($this->text);
     }
 
+    public function getFormattedTextWithExternalUrlAttribute()
+    {
+        $text = $this->text;
+        
+        if (!$this->isTweet() && $this->external_url) {
+            $text .= PHP_EOL . PHP_EOL . "[Read More]({$this->external_url})";
+        }
+
+        return CommonMark::convertToHtml($text);
+    }
+
     public function updateAttributes(array $attributes)
     {
         $this->title = $attributes['title'];
@@ -153,7 +164,7 @@ class Post extends Model implements Feedable, Sluggable, Tweetable
         return FeedItem::create()
             ->id($this->id)
             ->title($this->formatted_title)
-            ->summary($this->formatted_text)
+            ->summary($this->formatted_text_with_external_url)
             ->updated($this->publish_date)
             ->link($this->url)
             ->author('Freek Van der Herten');


### PR DESCRIPTION
When sharing a link, the RSS feed doesn't contain the "Read More" direct link to the shared post.

The `!$this->isTweet() && $this->external_url` is copied from the Blade view `front.posts.show`

I don't know if it's better to add the link in markdown then convert to HTML or to do the inverse, convert to HTML then add the link in HTML.

You may want to factor the `front.posts.show` logic by using the new accessor `formatted_text_with_external_url`.