### PR TITLE
New design for ogImages for blog posts

### DIFF
--- a/app/Models/Presenters/PostPresenter.php
+++ b/app/Models/Presenters/PostPresenter.php
@@ -147,18 +147,18 @@ trait PostPresenter
         $tagNames = $this->tags->pluck('name');
 
         if ($tagNames->contains('laravel')) {
-            return 'from-red-400 to-red-900';
+            return 'from-red-400 to-red-700';
         }
 
         if ($tagNames->contains('php')) {
-            return 'from-blue-500 to-blue-900';
+            return 'from-blue-500 to-blue-800';
         }
 
         if ($tagNames->contains('javascript')) {
-            return 'from-yellow-400 to-yellow-900';
+            return 'from-yellow-400 to-orange-500';
         }
 
-        return 'from-gray-400 to-gray-900';
+        return 'from-gray-400 to-gray-700';
     }
 
     public function getReadingTimeAttribute(): int

--- a/resources/views/front/posts/ogImage.blade.php
+++ b/resources/views/front/posts/ogImage.blade.php
@@ -3,10 +3,44 @@
     <style>{!! file_get_contents(public_path('css/app.css')) !!}</style>
     <link rel="stylesheet" href="https://cloud.typography.com/6194432/6581412/css/fonts.css"/>
 </head>
-
-<body class="pl-32 pr-32 pt-8">
-<x-post-header :post="$post" class="mb-8">
-    {!! $post->formatted_text !!}
-</x-post-header>
+<body>
+<div class="min-h-screen bg-gray-900 py-6 flex flex-col justify-center sm:py-12 p-20">
+    <div class="relative py-3">
+        <div
+            class="absolute inset-0 bg-gradient-to-r {{ $post->gradient_colors }} shadow-lg transform skew-y-0 -rotate-5 sm:rounded-3xl"></div>
+        <div class="relative px-4 py-10 bg-white shadow-lg sm:rounded-3xl sm:p-10">
+            <div class="mx-auto">
+                <div class="divide-y divide-gray-200">
+                    <div class="pb-4 text-base space-y-4 leading-9">
+                        <p class="text-3xl font-bold">{{ $post->title }}</p>
+                    </div>
+                    <div class="pt-6 text-base leading-6 font-bold sm:text-lg sm:leading-7">
+                        <div class="md:flex items-end">
+                            <figure class="w-12 inline-block mb-1 md:mb-0 md:mr-3">
+                                <a href="/" title="Freek.dev">
+                                    <img src="/images/murzicoon.svg" class="w-full" alt="Freek.dev logotype">
+                                </a>
+                            </figure>
+                            <div>
+                                <h1 class="text-lg uppercase tracking-wider font-extrabold">
+                                    <a href="/">Freek.dev</a>
+                                </h1>
+                                <p class="text-sm font-bold text-gray-600">
+                                    <a href="/">
+                                        Laravel
+                                        <span class="text-gray-300">/</span>
+                                        PHP
+                                        <span class="text-gray-300">/</span>
+                                        JavaScript
+                                    </a>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 </body>
 </html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -46,6 +46,17 @@ module.exports = {
             lineHeight: {
                 relaxed: 1.75,
             },
+            spacing: {
+                7: '1.75rem',
+            },
+            borderRadius: {
+                xl: '12px',
+                '2xl': '16px',
+                '3xl': '24px',
+            },
+            rotate: {
+                '-5': '-5deg',
+            },
         },
     },
     variants: {


### PR DESCRIPTION
Hey,
I've tried to make the og images for your blog posts look a bit nicer and that's what I've come up with.

I edited the colors for the different topics (laravel, php and javascript) slightly but I think it looks ok. I've got some inspiration from the new tailwindcss playground. 

**Laravel post:**
![Bildschirmfoto 2020-10-08 um 09 34 13](https://user-images.githubusercontent.com/22103266/95428553-73809000-0949-11eb-80c4-d5c39c9028df.png)

**PHP post**
![Bildschirmfoto 2020-10-08 um 09 37 01](https://user-images.githubusercontent.com/22103266/95428823-d6722700-0949-11eb-8857-23608a133d87.png)

**JavaScript**
![Bildschirmfoto 2020-10-08 um 09 40 44](https://user-images.githubusercontent.com/22103266/95429221-5ac4aa00-094a-11eb-93f7-00141a4d4c57.png)

**Any other**
![Bildschirmfoto 2020-10-08 um 09 41 56](https://user-images.githubusercontent.com/22103266/95429322-85aefe00-094a-11eb-88eb-fcefc9e8c1d2.png)
