### PR TITLE
Added gradient classes to purgeCSS whitelist

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,18 @@ module.exports = {
     },
     purge: {
         content: ['./resources/**/*.blade.php'],
+        options: {
+            whitelist: [
+                'from-red-400',
+                'to-red-700',
+                'from-blue-500',
+                'to-blue-800',
+                'from-yellow-400',
+                'to-orange-500',
+                'from-gray-400',
+                'to-gray-700'
+            ],
+        }
     },
     plugins: [require('@tailwindcss/custom-forms')],
     theme: {


### PR DESCRIPTION
When compiling the CSS in production mode PurgeCSS removes the gradient classes used for the og image generation, because they come from a controller and PurgeCSS doesn't look for css classes in controllers.

After whitelisting those in `tailwind.config.js` it works fine.