### PR TITLE
Replace biweekly word with a clearer description

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -25,7 +25,7 @@
                         <input class="form-checkbox" type="checkbox" name="newsletter"
                                id="newsletter" {{ old('newsletter') ? 'checked' : '' }}>
 
-                        <span class="text-sm ml-2">Subscribe me to <a href="/newsletter">the freek.dev newsletter</a>, a biweekly newsletter with useful links on PHP, Laravel and JavaScript</span>
+                        <span class="text-sm ml-2">Subscribe me to <a href="/newsletter">the freek.dev newsletter</a>, a newsletter published once every two weeks with useful links on PHP, Laravel and JavaScript</span>
                     </label>
                 </div>
 


### PR DESCRIPTION
Noticed the word occurrence after this [tweet](https://twitter.com/freekmurze/status/1321559995138351107).

Sources: [biweekly](https://www.collinsdictionary.com/pt/dictionary/english/biweekly) entry on Collins Dictionary. There is a word "fortnightly" as a regional note in British English.