### PR TITLE
Remove double `I'm a` from about page

### DIFF
--- a/resources/views/front/about/index.blade.php
+++ b/resources/views/front/about/index.blade.php
@@ -14,7 +14,7 @@
 
         </p>
         <p>
-            I'm a I'm a PHP developer and Laravel enthusiast. Most of my time is spent at <a href="https://spatie.be">Spatie</a> of which I'm the co-owner.
+            I'm a PHP developer and Laravel enthusiast. Most of my time is spent at <a href="https://spatie.be">Spatie</a> of which I'm the co-owner.
 
             <p>
             At Spatie we use a


### PR DESCRIPTION
I removed the double `I'm a` from the [about page](https://freek.dev/about)

```
I'm a I'm a PHP developer and Laravel enthusiast. Most of my time is spent at Spatie of which I'm the co-owner.
```