### PR TITLE
PHPUnit to Pest Converter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,7 +47,7 @@ jobs:
                     php artisan key:generate
 
             -   name: Run tests
-                run: ./vendor/bin/phpunit
+                run: ./vendor/bin/pest
                 env:
                     DB_PASSWORD: root
                     REDIS_PORT: ${{ job.services.redis.ports[6379] }}

--- a/composer.json
+++ b/composer.json
@@ -62,9 +62,10 @@
         "fakerphp/faker": "^1.9.1",
         "mockery/mockery": "^1.3.1",
         "nunomaduro/collision": "^5.0",
-        "phpunit/phpunit": "^9.3",
         "spatie/phpunit-snapshot-assertions": "^4.2",
-        "wulfheart/pretty_routes": "^0.1.2"
+        "wulfheart/pretty_routes": "^0.1.2",
+        "pestphp/pest": "^1.16",
+        "pestphp/pest-plugin-laravel": "^1.1"
     },
     "config": {
         "optimize-autoloader": true,

--- a/tests/Feature/Actions/ApproveLinkActionTest.php
+++ b/tests/Feature/Actions/ApproveLinkActionTest.php
@@ -1,51 +1,41 @@
 <?php
 
-namespace Tests\Feature\Actions;
-
 use App\Actions\ApproveLinkAction;
 use App\Mail\LinkApprovedMail;
 use App\Models\Link;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
-class ApproveLinkActionTest extends TestCase
-{
-    private ApproveLinkAction $approveLinkAction;
+uses(TestCase::class);
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    parent::setUp();
 
-        Mail::fake();
+    Mail::fake();
 
-        $this->approveLinkAction = app(ApproveLinkAction::class);
-    }
+    $this->approveLinkAction = app(ApproveLinkAction::class);
+});
 
-    /** @test */
-    public function the_action_can_approve_a_link()
-    {
-        /** @var Link $submittedLink */
-        $submittedLink = Link::factory()->create([
-            'status' => Link::STATUS_SUBMITTED,
-        ]);
+test('the action can approve a link', function () {
+    /** @var Link $submittedLink */
+    $submittedLink = Link::factory()->create([
+        'status' => Link::STATUS_SUBMITTED,
+    ]);
 
-        $this->approveLinkAction->execute($submittedLink);
+    $this->approveLinkAction->execute($submittedLink);
 
-        $this->assertEquals(Link::STATUS_APPROVED, $submittedLink->status);
+    $this->assertEquals(Link::STATUS_APPROVED, $submittedLink->status);
 
-        Mail::assertQueued(LinkApprovedMail::class, fn (LinkApprovedMail $mail) => $mail->hasTo($submittedLink->user->email));
-    }
+    Mail::assertQueued(LinkApprovedMail::class, fn (LinkApprovedMail $mail) => $mail->hasTo($submittedLink->user->email));
+});
 
-    /** @test */
-    public function it_will_not_send_a_mail_for_a_link_that_was_already_approved()
-    {
-        /** @var Link $submittedLink */
-        $approvedLink = Link::factory()->create([
-            'status' => Link::STATUS_APPROVED,
-        ]);
+it('will not send a mail for a link that was already approved', function () {
+    /** @var Link $submittedLink */
+    $approvedLink = Link::factory()->create([
+        'status' => Link::STATUS_APPROVED,
+    ]);
 
-        $this->approveLinkAction->execute($approvedLink);
+    $this->approveLinkAction->execute($approvedLink);
 
-        Mail::assertNothingQueued();
-    }
-}
+    Mail::assertNothingQueued();
+});

--- a/tests/Feature/Actions/ApproveLinkActionTest.php
+++ b/tests/Feature/Actions/ApproveLinkActionTest.php
@@ -24,7 +24,7 @@ test('the action can approve a link', function () {
 
     $this->approveLinkAction->execute($submittedLink);
 
-    $this->assertEquals(Link::STATUS_APPROVED, $submittedLink->status);
+    expect($submittedLink->status)->toEqual(Link::STATUS_APPROVED);
 
     Mail::assertQueued(LinkApprovedMail::class, fn (LinkApprovedMail $mail) => $mail->hasTo($submittedLink->user->email));
 });

--- a/tests/Feature/Actions/CreateLinkActionTest.php
+++ b/tests/Feature/Actions/CreateLinkActionTest.php
@@ -1,7 +1,4 @@
 <?php
 
-namespace Tests\Feature\Actions;
+uses(::class);
 
-class CreateLinkActionTest
-{
-}

--- a/tests/Feature/Actions/CreatePostFormLinkActionTest.php
+++ b/tests/Feature/Actions/CreatePostFormLinkActionTest.php
@@ -1,26 +1,21 @@
 <?php
 
-namespace Tests\Feature\Actions;
-
 use App\Actions\CreatePostFromLinkAction;
 use App\Models\Link;
 use Tests\TestCase;
 
-class CreatePostFormLinkActionTest extends TestCase
-{
-    /** @test */
-    public function it_can_create_a_post_from_a_link()
-    {
-        $link = Link::factory()->create();
+uses(TestCase::class);
 
-        (new CreatePostFromLinkAction())->execute($link);
+it('can create a post from a link', function () {
+    $link = Link::factory()->create();
 
-        $this->assertDatabaseHas('posts', [
-            'submitted_by_user_id' => $link->user_id,
-            'title' => $link->title,
-            'text' => $link->text,
-            'external_url' => $link->url,
-            'published' => false,
-        ]);
-    }
-}
+    (new CreatePostFromLinkAction())->execute($link);
+
+    $this->assertDatabaseHas('posts', [
+        'submitted_by_user_id' => $link->user_id,
+        'title' => $link->title,
+        'text' => $link->text,
+        'external_url' => $link->url,
+        'published' => false,
+    ]);
+});

--- a/tests/Feature/Actions/RejectLinkActionTest.php
+++ b/tests/Feature/Actions/RejectLinkActionTest.php
@@ -1,23 +1,18 @@
 <?php
 
-namespace Tests\Feature\Actions;
-
 use App\Actions\RejectLinkAction;
 use App\Models\Link;
 use Tests\TestCase;
 
-class RejectLinkActionTest extends TestCase
-{
-    /** @test */
-    public function it_can_reject_a_link()
-    {
-        /** @var Link $submittedLink */
-        $submittedLink = Link::factory()->create([
-            'status' => Link::STATUS_SUBMITTED,
-        ]);
+uses(TestCase::class);
 
-        (new RejectLinkAction())->execute($submittedLink);
+it('can reject a link', function () {
+    /** @var Link $submittedLink */
+    $submittedLink = Link::factory()->create([
+        'status' => Link::STATUS_SUBMITTED,
+    ]);
 
-        $this->assertEquals(Link::STATUS_REJECTED, $submittedLink->status);
-    }
-}
+    (new RejectLinkAction())->execute($submittedLink);
+
+    $this->assertEquals(Link::STATUS_REJECTED, $submittedLink->status);
+});

--- a/tests/Feature/Actions/RejectLinkActionTest.php
+++ b/tests/Feature/Actions/RejectLinkActionTest.php
@@ -14,5 +14,5 @@ it('can reject a link', function () {
 
     (new RejectLinkAction())->execute($submittedLink);
 
-    $this->assertEquals(Link::STATUS_REJECTED, $submittedLink->status);
+    expect($submittedLink->status)->toEqual(Link::STATUS_REJECTED);
 });

--- a/tests/Feature/Commands/UpdateExternalUrlsWithTweetPermalinksCommandTest.php
+++ b/tests/Feature/Commands/UpdateExternalUrlsWithTweetPermalinksCommandTest.php
@@ -12,7 +12,7 @@ it('can save the permalink of a tweet as the external url', function () {
 
     $this->artisan('blog:update-external-urls-with-tweet-permalinks');
 
-    $this->assertEquals('https://twitter.com/sebdedeyne/status/1130875746577264642?ref_src=twsrc%5Etfw', $tweetPost->refresh()->external_url);
+    expect($tweetPost->refresh()->external_url)->toEqual('https://twitter.com/sebdedeyne/status/1130875746577264642?ref_src=twsrc%5Etfw');
 });
 
 it('will not overwrite existing external urls', function () {
@@ -23,5 +23,5 @@ it('will not overwrite existing external urls', function () {
 
     $this->artisan('blog:update-external-urls-with-tweet-permalinks');
 
-    $this->assertEquals('https://already-exists.com', $tweetPost->refresh()->external_url);
+    expect($tweetPost->refresh()->external_url)->toEqual('https://already-exists.com');
 });

--- a/tests/Feature/Commands/UpdateExternalUrlsWithTweetPermalinksCommandTest.php
+++ b/tests/Feature/Commands/UpdateExternalUrlsWithTweetPermalinksCommandTest.php
@@ -1,34 +1,27 @@
 <?php
 
-namespace Tests\Feature\Commands;
-
 use Tests\Factories\PostFactory;
 use Tests\TestCase;
 
-class UpdateExternalUrlsWithTweetPermalinksCommandTest extends TestCase
-{
-    /** @test */
-    public function it_can_save_the_permalink_of_a_tweet_as_the_external_url()
-    {
-        $tweetPost = (new PostFactory())->tweet()->create([
-            'external_url' => null,
-        ]);
+uses(TestCase::class);
 
-        $this->artisan('blog:update-external-urls-with-tweet-permalinks');
+it('can save the permalink of a tweet as the external url', function () {
+    $tweetPost = (new PostFactory())->tweet()->create([
+        'external_url' => null,
+    ]);
 
-        $this->assertEquals('https://twitter.com/sebdedeyne/status/1130875746577264642?ref_src=twsrc%5Etfw', $tweetPost->refresh()->external_url);
-    }
+    $this->artisan('blog:update-external-urls-with-tweet-permalinks');
 
-    /** @test */
-    public function it_will_not_overwrite_existing_external_urls()
-    {
-        $tweetPost = (new PostFactory())->tweet()->create();
+    $this->assertEquals('https://twitter.com/sebdedeyne/status/1130875746577264642?ref_src=twsrc%5Etfw', $tweetPost->refresh()->external_url);
+});
 
-        $tweetPost->external_url = 'https://already-exists.com';
-        $tweetPost->save();
+it('will not overwrite existing external urls', function () {
+    $tweetPost = (new PostFactory())->tweet()->create();
 
-        $this->artisan('blog:update-external-urls-with-tweet-permalinks');
+    $tweetPost->external_url = 'https://already-exists.com';
+    $tweetPost->save();
 
-        $this->assertEquals('https://already-exists.com', $tweetPost->refresh()->external_url);
-    }
-}
+    $this->artisan('blog:update-external-urls-with-tweet-permalinks');
+
+    $this->assertEquals('https://already-exists.com', $tweetPost->refresh()->external_url);
+});

--- a/tests/Feature/Controllers/ApproveLinkAndCreatePostControllerTest.php
+++ b/tests/Feature/Controllers/ApproveLinkAndCreatePostControllerTest.php
@@ -13,11 +13,11 @@ it('can approve a link and create a post using a signed url', function () {
         'status' => Link::STATUS_SUBMITTED,
     ]);
 
-    $this->assertFalse($link->isApproved());
+    expect($link->isApproved())->toBeFalse();
 
     $this->get($link->approveAndCreatePostUrl());
 
-    $this->assertTrue($link->refresh()->isApproved());
+    expect($link->refresh()->isApproved())->toBeTrue();
     $this->assertDatabaseHas('posts', [
         'title' => $link->title,
     ]);

--- a/tests/Feature/Controllers/ApproveLinkAndCreatePostControllerTest.php
+++ b/tests/Feature/Controllers/ApproveLinkAndCreatePostControllerTest.php
@@ -1,30 +1,25 @@
 <?php
 
-namespace Tests\Feature\Controllers;
-
 use App\Models\Link;
 use Mail;
 use Tests\TestCase;
 
-class ApproveLinkAndCreatePostControllerTest extends TestCase
-{
-    /** @test */
-    public function it_can_approve_a_link_and_create_a_post_using_a_signed_url()
-    {
-        Mail::fake();
+uses(TestCase::class);
 
-        /** @var \App\Models\Link $link */
-        $link = Link::factory()->create([
-            'status' => Link::STATUS_SUBMITTED,
-        ]);
+it('can approve a link and create a post using a signed url', function () {
+    Mail::fake();
 
-        $this->assertFalse($link->isApproved());
+    /** @var \App\Models\Link $link */
+    $link = Link::factory()->create([
+        'status' => Link::STATUS_SUBMITTED,
+    ]);
 
-        $this->get($link->approveAndCreatePostUrl());
+    $this->assertFalse($link->isApproved());
 
-        $this->assertTrue($link->refresh()->isApproved());
-        $this->assertDatabaseHas('posts', [
-            'title' => $link->title,
-        ]);
-    }
-}
+    $this->get($link->approveAndCreatePostUrl());
+
+    $this->assertTrue($link->refresh()->isApproved());
+    $this->assertDatabaseHas('posts', [
+        'title' => $link->title,
+    ]);
+});

--- a/tests/Feature/Controllers/ApproveLinkAndCreatePostControllerTest.php
+++ b/tests/Feature/Controllers/ApproveLinkAndCreatePostControllerTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Models\Link;
-use Mail;
 use Tests\TestCase;
 
 uses(TestCase::class);

--- a/tests/Feature/Controllers/ApproveLinkControllerTest.php
+++ b/tests/Feature/Controllers/ApproveLinkControllerTest.php
@@ -14,11 +14,11 @@ it('can approve a link using a signed url', function () {
         'status' => Link::STATUS_SUBMITTED,
     ]);
 
-    $this->assertFalse($link->isApproved());
+    expect($link->isApproved())->toBeFalse();
 
     $this->get($link->approveUrl());
 
-    $this->assertTrue($link->refresh()->isApproved());
+    expect($link->refresh()->isApproved())->toBeTrue();
 
     Mail::assertQueued(LinkApprovedMail::class);
 });

--- a/tests/Feature/Controllers/ApproveLinkControllerTest.php
+++ b/tests/Feature/Controllers/ApproveLinkControllerTest.php
@@ -2,7 +2,6 @@
 
 use App\Mail\LinkApprovedMail;
 use App\Models\Link;
-use Mail;
 use Tests\TestCase;
 
 uses(TestCase::class);

--- a/tests/Feature/Controllers/ApproveLinkControllerTest.php
+++ b/tests/Feature/Controllers/ApproveLinkControllerTest.php
@@ -1,30 +1,25 @@
 <?php
 
-namespace Tests\Feature\Controllers;
-
 use App\Mail\LinkApprovedMail;
 use App\Models\Link;
 use Mail;
 use Tests\TestCase;
 
-class ApproveLinkControllerTest extends TestCase
-{
-    /** @test */
-    public function it_can_approve_a_link_using_a_signed_url()
-    {
-        Mail::fake();
+uses(TestCase::class);
 
-        /** @var \App\Models\Link $link */
-        $link = Link::factory()->create([
-            'status' => Link::STATUS_SUBMITTED,
-        ]);
+it('can approve a link using a signed url', function () {
+    Mail::fake();
 
-        $this->assertFalse($link->isApproved());
+    /** @var \App\Models\Link $link */
+    $link = Link::factory()->create([
+        'status' => Link::STATUS_SUBMITTED,
+    ]);
 
-        $this->get($link->approveUrl());
+    $this->assertFalse($link->isApproved());
 
-        $this->assertTrue($link->refresh()->isApproved());
+    $this->get($link->approveUrl());
 
-        Mail::assertQueued(LinkApprovedMail::class);
-    }
-}
+    $this->assertTrue($link->refresh()->isApproved());
+
+    Mail::assertQueued(LinkApprovedMail::class);
+});

--- a/tests/Feature/Controllers/CreateLinkControllerTest.php
+++ b/tests/Feature/Controllers/CreateLinkControllerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Controllers;
-
 use App\Http\Controllers\Links\CreateLinkController;
 use App\Mail\LinkSubmittedMail;
 use App\Models\Link;
@@ -9,73 +7,66 @@ use App\Models\User;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
-class CreateLinkControllerTest extends TestCase
+uses(TestCase::class);
+
+beforeEach(function () {
+    parent::setUp();
+
+    $this->user = User::factory()->create();
+
+    $this->actingAs($this->user);
+
+    Mail::fake();
+});
+
+it('will not accept a link that was already submitted', function () {
+    $this->withExceptionHandling();
+
+    $attributes = [
+        'title' => 'my title',
+        'text' => 'my text',
+        'url' => 'https://freek.dev',
+    ];
+
+    $this
+        ->post(action([CreateLinkController::class, 'store'], $attributes))
+        ->assertRedirect(route('links.thanks'));
+
+    $this
+        ->post(action([CreateLinkController::class, 'store'], $attributes))
+        ->assertSessionHasErrors('url');
+});
+
+it('can create a link without text', function () {
+    $attributes = [
+        'title' => 'my title',
+        'url' => 'https://freek.dev',
+    ];
+
+    $this
+        ->post(action([CreateLinkController::class, 'store'], $attributes))
+        ->assertRedirect(route('links.thanks'));
+});
+
+// Helpers
+function it_can_create_a_link()
 {
-    private User $user;
+    $attributes = [
+        'title' => 'my title',
+        'text' => 'my text',
+        'url' => 'https://freek.dev',
+    ];
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+    $this
+        ->post(action([CreateLinkController::class, 'store'], $attributes))
+        ->assertRedirect(route('links.thanks'));
 
-        $this->user = User::factory()->create();
+    $expectedAttributes = array_merge([
+        'user_id' => $this->user->id,
+        'status' => Link::STATUS_SUBMITTED,
+    ], $attributes);
 
-        $this->actingAs($this->user);
+    $this->assertDatabaseHas('links', $expectedAttributes);
 
-        Mail::fake();
-    }
-
-    public function it_can_create_a_link()
-    {
-        $attributes = [
-            'title' => 'my title',
-            'text' => 'my text',
-            'url' => 'https://freek.dev',
-        ];
-
-        $this
-            ->post(action([CreateLinkController::class, 'store'], $attributes))
-            ->assertRedirect(route('links.thanks'));
-
-        $expectedAttributes = array_merge([
-            'user_id' => $this->user->id,
-            'status' => Link::STATUS_SUBMITTED,
-        ], $attributes);
-
-        $this->assertDatabaseHas('links', $expectedAttributes);
-
-        Mail::assertQueued(LinkSubmittedMail::class);
-    }
-
-    /** @test */
-    public function it_will_not_accept_a_link_that_was_already_submitted()
-    {
-        $this->withExceptionHandling();
-
-        $attributes = [
-            'title' => 'my title',
-            'text' => 'my text',
-            'url' => 'https://freek.dev',
-        ];
-
-        $this
-            ->post(action([CreateLinkController::class, 'store'], $attributes))
-            ->assertRedirect(route('links.thanks'));
-
-        $this
-            ->post(action([CreateLinkController::class, 'store'], $attributes))
-            ->assertSessionHasErrors('url');
-    }
-
-    /** @test */
-    public function it_can_create_a_link_without_text()
-    {
-        $attributes = [
-            'title' => 'my title',
-            'url' => 'https://freek.dev',
-        ];
-
-        $this
-            ->post(action([CreateLinkController::class, 'store'], $attributes))
-            ->assertRedirect(route('links.thanks'));
-    }
+    Mail::assertQueued(LinkSubmittedMail::class);
 }

--- a/tests/Feature/Controllers/RejectLinkControllerTest.php
+++ b/tests/Feature/Controllers/RejectLinkControllerTest.php
@@ -11,9 +11,9 @@ it('can reject a link using a signed url', function () {
         'status' => Link::STATUS_SUBMITTED,
     ]);
 
-    $this->assertFalse($link->isRejected());
+    expect($link->isRejected())->toBeFalse();
 
     $this->get($link->rejectUrl());
 
-    $this->assertTrue($link->refresh()->isRejected());
+    expect($link->refresh()->isRejected())->toBeTrue();
 });

--- a/tests/Feature/Controllers/RejectLinkControllerTest.php
+++ b/tests/Feature/Controllers/RejectLinkControllerTest.php
@@ -1,24 +1,19 @@
 <?php
 
-namespace Tests\Feature\Controllers;
-
 use App\Models\Link;
 use Tests\TestCase;
 
-class RejectLinkControllerTest extends TestCase
-{
-    /** @test */
-    public function it_can_reject_a_link_using_a_signed_url()
-    {
-        /** @var \App\Models\Link $link */
-        $link = Link::factory()->create([
-            'status' => Link::STATUS_SUBMITTED,
-        ]);
+uses(TestCase::class);
 
-        $this->assertFalse($link->isRejected());
+it('can reject a link using a signed url', function () {
+    /** @var \App\Models\Link $link */
+    $link = Link::factory()->create([
+        'status' => Link::STATUS_SUBMITTED,
+    ]);
 
-        $this->get($link->rejectUrl());
+    $this->assertFalse($link->isRejected());
 
-        $this->assertTrue($link->refresh()->isRejected());
-    }
-}
+    $this->get($link->rejectUrl());
+
+    $this->assertTrue($link->refresh()->isRejected());
+});

--- a/tests/Feature/Models/PostTest.php
+++ b/tests/Feature/Models/PostTest.php
@@ -76,12 +76,12 @@ it('can render a series toc and next link on post', function () {
 it('can get the twitter handle of the author', function () {
     /** @var Post $post */
     $post = Post::factory()->create(['author_twitter_handle' => null]);
-    $this->assertNull($post->authorTwitterHandle());
+    expect($post->authorTwitterHandle())->toBeNull();
 
     $user = User::factory()->create(['twitter_handle' => 'other']);
     $post->update(['submitted_by_user_id' => $user->id]);
-    $this->assertEquals('other', $post->refresh()->authorTwitterHandle());
+    expect($post->refresh()->authorTwitterHandle())->toEqual('other');
 
     $post->update(['author_twitter_handle' => 'freekmurze']);
-    $this->assertEquals('freekmurze', $post->authorTwitterHandle());
+    expect($post->authorTwitterHandle())->toEqual('freekmurze');
 });

--- a/tests/Feature/Models/PostTest.php
+++ b/tests/Feature/Models/PostTest.php
@@ -1,7 +1,5 @@
 <?php
 
-namespace Tests\Feature\Models;
-
 use App\Http\Controllers\PostController;
 use App\Models\Post;
 use App\Models\User;
@@ -9,100 +7,81 @@ use Spatie\Snapshots\MatchesSnapshots;
 use Tests\Factories\PostFactory;
 use Tests\TestCase;
 
-class PostTest extends TestCase
-{
-    use MatchesSnapshots;
+uses(TestCase::class);
+uses(MatchesSnapshots::class);
 
-    private Post $post;
+beforeEach(function () {
+    parent::setUp();
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+    $this->post = Post::factory()->create();
+});
 
-        $this->post = Post::factory()->create();
-    }
+it('can find a post by its id slug', function () {
+    $this->withoutExceptionHandling();
 
-    /** @test */
-    public function it_can_find_a_post_by_its_id_slug()
-    {
-        $this->withoutExceptionHandling();
+    $this
+        ->get(action(PostController::class, $this->post->idSlug()))
+        ->assertSuccessful()
+        ->assertSee($this->post->title);
+});
 
-        $this
-            ->get(action(PostController::class, $this->post->idSlug()))
-            ->assertSuccessful()
-            ->assertSee($this->post->title);
-    }
+it('can redirects a slug to an id slug', function () {
+    $this
+        ->get(action(PostController::class, $this->post->slug))
+        ->assertRedirect(action(PostController::class, $this->post->idSlug()));
+});
 
-    /** @test */
-    public function it_can_redirects_a_slug_to_an_id_slug()
-    {
-        $this
-            ->get(action(PostController::class, $this->post->slug))
-            ->assertRedirect(action(PostController::class, $this->post->idSlug()));
-    }
+it('will return a 404 for an invalid slug', function () {
+    $this
+        ->get(action(PostController::class, 'invalid'))
+        ->assertNotFound();
+});
 
-    /** @test */
-    public function it_will_return_a_404_for_an_invalid_slug()
-    {
-        $this
-            ->get(action(PostController::class, 'invalid'))
-            ->assertNotFound();
-    }
+it('will only show posts with a publish date in the future', function () {
+    $post = Post::factory()->create([
+        'published' => false,
+    ]);
 
-    /** @test */
-    public function it_will_only_show_posts_with_a_publish_date_in_the_future()
-    {
-        $post = Post::factory()->create([
-            'published' => false,
-        ]);
+    $this
+        ->get(action(PostController::class, $post->idSlug()))
+        ->assertNotFound();
+});
 
-        $this
-            ->get(action(PostController::class, $post->idSlug()))
-            ->assertNotFound();
-    }
+it('will display unpublished post using a preview secret', function () {
+    $post = Post::factory()->create([
+        'published' => false,
+    ]);
 
-    /** @test */
-    public function it_will_display_unpublished_post_using_a_preview_secret()
-    {
-        $post = Post::factory()->create([
-            'published' => false,
-        ]);
+    $this
+        ->get(action(PostController::class, $post->idSlug()))
+        ->assertNotFound();
 
-        $this
-            ->get(action(PostController::class, $post->idSlug()))
-            ->assertNotFound();
+    $this
+        ->get(action(PostController::class, $post->idSlug()) . "?preview_secret={$post->preview_secret}")
+        ->assertSuccessful();
 
-        $this
-            ->get(action(PostController::class, $post->idSlug()) . "?preview_secret={$post->preview_secret}")
-            ->assertSuccessful();
+    $this
+        ->get(action(PostController::class, $post->idSlug()) . "?preview_secret=wrong-secret")
+        ->assertNotFound();
+});
 
-        $this
-            ->get(action(PostController::class, $post->idSlug()) . "?preview_secret=wrong-secret")
-            ->assertNotFound();
-    }
+it('can render a series toc and next link on post', function () {
+    $posts = PostFactory::series(10);
 
-    /** @test */
-    public function it_can_render_a_series_toc_and_next_link_on_post()
-    {
-        $posts = PostFactory::series(10);
+    ray()->newScreen('rendering');
 
-        ray()->newScreen('rendering');
+    $this->assertMatchesHtmlSnapshot($posts->first()->refresh()->html);
+});
 
-        $this->assertMatchesHtmlSnapshot($posts->first()->refresh()->html);
-    }
+it('can get the twitter handle of the author', function () {
+    /** @var Post $post */
+    $post = Post::factory()->create(['author_twitter_handle' => null]);
+    $this->assertNull($post->authorTwitterHandle());
 
-    /** @test */
-    public function it_can_get_the_twitter_handle_of_the_author()
-    {
-        /** @var Post $post */
-        $post = Post::factory()->create(['author_twitter_handle' => null]);
-        $this->assertNull($post->authorTwitterHandle());
+    $user = User::factory()->create(['twitter_handle' => 'other']);
+    $post->update(['submitted_by_user_id' => $user->id]);
+    $this->assertEquals('other', $post->refresh()->authorTwitterHandle());
 
-        $user = User::factory()->create(['twitter_handle' => 'other']);
-        $post->update(['submitted_by_user_id' => $user->id]);
-        $this->assertEquals('other', $post->refresh()->authorTwitterHandle());
-
-        $post->update(['author_twitter_handle' => 'freekmurze']);
-        $this->assertEquals('freekmurze', $post->authorTwitterHandle());
-    }
-}
+    $post->update(['author_twitter_handle' => 'freekmurze']);
+    $this->assertEquals('freekmurze', $post->authorTwitterHandle());
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "uses()" function to bind a different classes or traits.
+|
+*/
+
+/** @link https://pestphp.com/docs/underlying-test-case */
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+/** @link https://pestphp.com/docs/expectations#custom-expectations */
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/** @link https://pestphp.com/docs/helpers */

--- a/tests/Unit/Mails/LinkApprovedMailTest.php
+++ b/tests/Unit/Mails/LinkApprovedMailTest.php
@@ -9,5 +9,5 @@ uses(TestCase::class);
 test('the link approved mail can be rendered', function () {
     $link = Link::factory()->create();
 
-    $this->assertIsString((new LinkApprovedMail($link))->render());
+    expect((new LinkApprovedMail($link))->render())->toBeString();
 });

--- a/tests/Unit/Mails/LinkApprovedMailTest.php
+++ b/tests/Unit/Mails/LinkApprovedMailTest.php
@@ -1,18 +1,13 @@
 <?php
 
-namespace Tests\Unit\Mails;
-
 use App\Mail\LinkApprovedMail;
 use App\Models\Link;
 use Tests\TestCase;
 
-class LinkApprovedMailTest extends TestCase
-{
-    /** @test */
-    public function the_link_approved_mail_can_be_rendered()
-    {
-        $link = Link::factory()->create();
+uses(TestCase::class);
 
-        $this->assertIsString((new LinkApprovedMail($link))->render());
-    }
-}
+test('the link approved mail can be rendered', function () {
+    $link = Link::factory()->create();
+
+    $this->assertIsString((new LinkApprovedMail($link))->render());
+});

--- a/tests/Unit/Mails/LinkSubmittedMailTest.php
+++ b/tests/Unit/Mails/LinkSubmittedMailTest.php
@@ -9,5 +9,5 @@ uses(TestCase::class);
 test('the link approved mail can be rendered', function () {
     $link = Link::factory()->create();
 
-    $this->assertIsString((new LinkSubmittedMail($link))->render());
+    expect((new LinkSubmittedMail($link))->render())->toBeString();
 });

--- a/tests/Unit/Mails/LinkSubmittedMailTest.php
+++ b/tests/Unit/Mails/LinkSubmittedMailTest.php
@@ -1,18 +1,13 @@
 <?php
 
-namespace Tests\Unit\Mails;
-
 use App\Mail\LinkSubmittedMail;
 use App\Models\Link;
 use Tests\TestCase;
 
-class LinkSubmittedMailTest extends TestCase
-{
-    /** @test */
-    public function the_link_approved_mail_can_be_rendered()
-    {
-        $link = Link::factory()->create();
+uses(TestCase::class);
 
-        $this->assertIsString((new LinkSubmittedMail($link))->render());
-    }
-}
+test('the link approved mail can be rendered', function () {
+    $link = Link::factory()->create();
+
+    $this->assertIsString((new LinkSubmittedMail($link))->render());
+});

--- a/tests/Unit/Models/AdTest.php
+++ b/tests/Unit/Models/AdTest.php
@@ -12,29 +12,29 @@ it('can get an ad for the current date', function () {
     $februaryAd = createAdForYearMonth(2018, 2);
 
     $this->setNow(2017, 12, 31);
-    $this->assertNull(Ad::getForPage());
+    expect(Ad::getForPage())->toBeNull();
 
     $this->setNow(2018, 1, 1, 1, 0, 0);
 
-    $this->assertEquals($januaryAd->id, Ad::getForPage()->id);
+    expect(Ad::getForPage()->id)->toEqual($januaryAd->id);
 
     $this->setNow(2018, 1, 15, 0, 0, 0);
-    $this->assertEquals($januaryAd->id, Ad::getForPage()->id);
+    expect(Ad::getForPage()->id)->toEqual($januaryAd->id);
 
     $this->setNow(2018, 1, 31, 0, 0, 0);
-    $this->assertEquals($januaryAd->id, Ad::getForPage()->id);
+    expect(Ad::getForPage()->id)->toEqual($januaryAd->id);
 
     $this->setNow(2018, 2, 1, 0, 0, 0);
-    $this->assertEquals($februaryAd->id, Ad::getForPage()->id);
+    expect(Ad::getForPage()->id)->toEqual($februaryAd->id);
 
     $this->setNow(2018, 2, 15, 0, 0, 0);
-    $this->assertEquals($februaryAd->id, Ad::getForPage()->id);
+    expect(Ad::getForPage()->id)->toEqual($februaryAd->id);
 
     $this->setNow(2018, 2, 28, 0, 0, 0);
-    $this->assertEquals($februaryAd->id, Ad::getForPage()->id);
+    expect(Ad::getForPage()->id)->toEqual($februaryAd->id);
 
     $this->setNow(2018, 3, 1, 0, 0, 0);
-    $this->assertNull(Ad::getForPage());
+    expect(Ad::getForPage())->toBeNull();
 });
 
 test('an url specific ad will be displayed on that url', function () {
@@ -42,9 +42,9 @@ test('an url specific ad will be displayed on that url', function () {
 
     $ad = createAdForYearMonth(2018, 1, ['display_on_url' => 'test-url']);
 
-    $this->assertNull(Ad::getForPage());
+    expect(Ad::getForPage())->toBeNull();
 
-    $this->assertEquals($ad->id, Ad::getForPage('test-url')->id);
+    expect(Ad::getForPage('test-url')->id)->toEqual($ad->id);
 });
 
 test('a url specific ad takes precedence over the site wide one', function () {
@@ -54,9 +54,9 @@ test('a url specific ad takes precedence over the site wide one', function () {
 
     $siteWideAd = createAdForYearMonth(2018, 1);
 
-    $this->assertEquals($urlSpecificAd->id, Ad::getForPage('test-url')->id);
+    expect(Ad::getForPage('test-url')->id)->toEqual($urlSpecificAd->id);
 
-    $this->assertEquals($siteWideAd->id, Ad::getForPage('another-url')->id);
+    expect(Ad::getForPage('another-url')->id)->toEqual($siteWideAd->id);
 });
 
 // Helpers

--- a/tests/Unit/Models/AdTest.php
+++ b/tests/Unit/Models/AdTest.php
@@ -1,85 +1,77 @@
 <?php
 
-namespace Tests\Unit\Models;
-
 use App\Models\Ad;
 use Carbon\Carbon;
 use Tests\TestCase;
 
-class AdTest extends TestCase
+uses(TestCase::class);
+
+it('can get an ad for the current date', function () {
+    $januaryAd = createAdForYearMonth(2018, 1);
+
+    $februaryAd = createAdForYearMonth(2018, 2);
+
+    $this->setNow(2017, 12, 31);
+    $this->assertNull(Ad::getForPage());
+
+    $this->setNow(2018, 1, 1, 1, 0, 0);
+
+    $this->assertEquals($januaryAd->id, Ad::getForPage()->id);
+
+    $this->setNow(2018, 1, 15, 0, 0, 0);
+    $this->assertEquals($januaryAd->id, Ad::getForPage()->id);
+
+    $this->setNow(2018, 1, 31, 0, 0, 0);
+    $this->assertEquals($januaryAd->id, Ad::getForPage()->id);
+
+    $this->setNow(2018, 2, 1, 0, 0, 0);
+    $this->assertEquals($februaryAd->id, Ad::getForPage()->id);
+
+    $this->setNow(2018, 2, 15, 0, 0, 0);
+    $this->assertEquals($februaryAd->id, Ad::getForPage()->id);
+
+    $this->setNow(2018, 2, 28, 0, 0, 0);
+    $this->assertEquals($februaryAd->id, Ad::getForPage()->id);
+
+    $this->setNow(2018, 3, 1, 0, 0, 0);
+    $this->assertNull(Ad::getForPage());
+});
+
+test('an url specific ad will be displayed on that url', function () {
+    $this->setNow(2018, 1, 1);
+
+    $ad = createAdForYearMonth(2018, 1, ['display_on_url' => 'test-url']);
+
+    $this->assertNull(Ad::getForPage());
+
+    $this->assertEquals($ad->id, Ad::getForPage('test-url')->id);
+});
+
+test('a url specific ad takes precedence over the site wide one', function () {
+    $this->setNow(2018, 1, 1, 0, 0, 0);
+
+    $urlSpecificAd = createAdForYearMonth(2018, 1, ['display_on_url' => 'test-url']);
+
+    $siteWideAd = createAdForYearMonth(2018, 1);
+
+    $this->assertEquals($urlSpecificAd->id, Ad::getForPage('test-url')->id);
+
+    $this->assertEquals($siteWideAd->id, Ad::getForPage('another-url')->id);
+});
+
+// Helpers
+function createAdForYearMonth(int $year, int $month, array $attributes = []): Ad
 {
-    /** @test */
-    public function it_can_get_an_ad_for_the_current_date()
-    {
-        $januaryAd = $this->createAdForYearMonth(2018, 1);
+    $startsAt = Carbon::createFromDate($year, $month, 1)->startOfMonth();
+    $endsAt = $startsAt->copy()->endOfMonth();
 
-        $februaryAd = $this->createAdForYearMonth(2018, 2);
+    $defaultAttributes = [
+        'display_on_url' => null,
+        'starts_at' => $startsAt->format('Y-m-d'),
+        'ends_at' => $endsAt->format('Y-m-d'),
+    ];
 
-        $this->setNow(2017, 12, 31);
-        $this->assertNull(Ad::getForPage());
+    $attributes = array_merge($defaultAttributes, $attributes);
 
-        $this->setNow(2018, 1, 1, 1, 0, 0);
-
-        $this->assertEquals($januaryAd->id, Ad::getForPage()->id);
-
-        $this->setNow(2018, 1, 15, 0, 0, 0);
-        $this->assertEquals($januaryAd->id, Ad::getForPage()->id);
-
-        $this->setNow(2018, 1, 31, 0, 0, 0);
-        $this->assertEquals($januaryAd->id, Ad::getForPage()->id);
-
-        $this->setNow(2018, 2, 1, 0, 0, 0);
-        $this->assertEquals($februaryAd->id, Ad::getForPage()->id);
-
-        $this->setNow(2018, 2, 15, 0, 0, 0);
-        $this->assertEquals($februaryAd->id, Ad::getForPage()->id);
-
-        $this->setNow(2018, 2, 28, 0, 0, 0);
-        $this->assertEquals($februaryAd->id, Ad::getForPage()->id);
-
-        $this->setNow(2018, 3, 1, 0, 0, 0);
-        $this->assertNull(Ad::getForPage());
-    }
-
-    /** @test */
-    public function an_url_specific_ad_will_be_displayed_on_that_url()
-    {
-        $this->setNow(2018, 1, 1);
-
-        $ad = $this->createAdForYearMonth(2018, 1, ['display_on_url' => 'test-url']);
-
-        $this->assertNull(Ad::getForPage());
-
-        $this->assertEquals($ad->id, Ad::getForPage('test-url')->id);
-    }
-
-    /** @test */
-    public function a_url_specific_ad_takes_precedence_over_the_site_wide_one()
-    {
-        $this->setNow(2018, 1, 1, 0, 0, 0);
-
-        $urlSpecificAd = $this->createAdForYearMonth(2018, 1, ['display_on_url' => 'test-url']);
-
-        $siteWideAd = $this->createAdForYearMonth(2018, 1);
-
-        $this->assertEquals($urlSpecificAd->id, Ad::getForPage('test-url')->id);
-
-        $this->assertEquals($siteWideAd->id, Ad::getForPage('another-url')->id);
-    }
-
-    protected function createAdForYearMonth(int $year, int $month, array $attributes = []): Ad
-    {
-        $startsAt = Carbon::createFromDate($year, $month, 1)->startOfMonth();
-        $endsAt = $startsAt->copy()->endOfMonth();
-
-        $defaultAttributes = [
-            'display_on_url' => null,
-            'starts_at' => $startsAt->format('Y-m-d'),
-            'ends_at' => $endsAt->format('Y-m-d'),
-        ];
-
-        $attributes = array_merge($defaultAttributes, $attributes);
-
-        return Ad::factory()->create($attributes);
-    }
+    return Ad::factory()->create($attributes);
 }

--- a/tests/Unit/Models/Concerns/HasSlugTest.php
+++ b/tests/Unit/Models/Concerns/HasSlugTest.php
@@ -10,17 +10,17 @@ test('a model can have a slug', function () {
 
     $this->assertNotEmpty($post->slug);
 
-    $this->assertEquals("{$post->id}-{$post->slug}", $post->idSlug());
+    expect($post->idSlug())->toEqual("{$post->id}-{$post->slug}");
 });
 
 test('a model can be found by an id slug', function () {
     $post = Post::factory()->create();
 
-    $this->assertEquals($post->id, Post::findByIdSlug($post->idSlug())->id);
+    expect(Post::findByIdSlug($post->idSlug())->id)->toEqual($post->id);
 
-    $this->assertEquals($post->id, Post::findByIdSlug($post->id . 'blabla')->id);
+    expect(Post::findByIdSlug($post->id . 'blabla')->id)->toEqual($post->id);
 
-    $this->assertEquals($post->id, Post::findByIdSlug($post->id)->id);
+    expect(Post::findByIdSlug($post->id)->id)->toEqual($post->id);
 
-    $this->assertNull(Post::findByIdSlug(1234 . 'blabla'));
+    expect(Post::findByIdSlug(1234 . 'blabla'))->toBeNull();
 });

--- a/tests/Unit/Models/Concerns/HasSlugTest.php
+++ b/tests/Unit/Models/Concerns/HasSlugTest.php
@@ -1,33 +1,26 @@
 <?php
 
-namespace Tests\Unit\Models\Concerns;
-
 use App\Models\Post;
 use Tests\TestCase;
 
-class HasSlugTest extends TestCase
-{
-    /** @test */
-    public function a_model_can_have_a_slug()
-    {
-        $post = Post::factory()->create();
+uses(TestCase::class);
 
-        $this->assertNotEmpty($post->slug);
+test('a model can have a slug', function () {
+    $post = Post::factory()->create();
 
-        $this->assertEquals("{$post->id}-{$post->slug}", $post->idSlug());
-    }
+    $this->assertNotEmpty($post->slug);
 
-    /** @test */
-    public function a_model_can_be_found_by_an_id_slug()
-    {
-        $post = Post::factory()->create();
+    $this->assertEquals("{$post->id}-{$post->slug}", $post->idSlug());
+});
 
-        $this->assertEquals($post->id, Post::findByIdSlug($post->idSlug())->id);
+test('a model can be found by an id slug', function () {
+    $post = Post::factory()->create();
 
-        $this->assertEquals($post->id, Post::findByIdSlug($post->id . 'blabla')->id);
+    $this->assertEquals($post->id, Post::findByIdSlug($post->idSlug())->id);
 
-        $this->assertEquals($post->id, Post::findByIdSlug($post->id)->id);
+    $this->assertEquals($post->id, Post::findByIdSlug($post->id . 'blabla')->id);
 
-        $this->assertNull(Post::findByIdSlug(1234 . 'blabla'));
-    }
-}
+    $this->assertEquals($post->id, Post::findByIdSlug($post->id)->id);
+
+    $this->assertNull(Post::findByIdSlug(1234 . 'blabla'));
+});

--- a/tests/Unit/Models/PostTest.php
+++ b/tests/Unit/Models/PostTest.php
@@ -25,56 +25,56 @@ it('can determine the promotional url', function () {
 });
 
 it('can get scheduled posts', function () {
-    $this->assertCount(0, Post::scheduled()->get());
+    expect(Post::scheduled()->get())->toHaveCount(0);
 
     Post::factory()->create([
         'publish_date' => now()->subMinute(),
         'published' => false,
     ]);
-    $this->assertCount(1, Post::scheduled()->get());
+    expect(Post::scheduled()->get())->toHaveCount(1);
 
     Post::factory()->create([
         'publish_date' => now()->subMinute(),
         'published' => true,
     ]);
-    $this->assertCount(1, Post::scheduled()->get());
+    expect(Post::scheduled()->get())->toHaveCount(1);
 
     Post::factory()->create([
         'publish_date' => now()->addMinute(),
         'published' => false,
     ]);
-    $this->assertCount(2, Post::scheduled()->get());
+    expect(Post::scheduled()->get())->toHaveCount(2);
 
     Post::factory()->create([
         'publish_date' => null,
         'published' => false,
     ]);
-    $this->assertCount(2, Post::scheduled()->get());
+    expect(Post::scheduled()->get())->toHaveCount(2);
 });
 
 it('can determine if the post concerns a tweet', function () {
     $post = Post::factory()->create();
 
-    $this->assertFalse($post->isTweet());
+    expect($post->isTweet())->toBeFalse();
 
     $post->syncTags(['php', 'tweet']);
 
-    $this->assertTrue($post->refresh()->isTweet());
+    expect($post->refresh()->isTweet())->toBeTrue();
 });
 
 it('can determine that a post is a tweet', function () {
     $post = Post::factory()->create();
-    $this->assertFalse($post->isTweet());
+    expect($post->isTweet())->toBeFalse();
 
     $post = Post::factory()->create()->attachTag('tweet');
-    $this->assertTrue($post->isTweet());
+    expect($post->isTweet())->toBeTrue();
 
     $post = Post::factory()->create()->attachTags([
         'tag',
         'tweet',
         'another-tag',
     ]);
-    $this->assertTrue($post->isTweet());
+    expect($post->isTweet())->toBeTrue();
 });
 
 it('can determine the excerpt', function () {
@@ -82,14 +82,14 @@ it('can determine the excerpt', function () {
        'text' => 'excerpt<!--more-->full post',
     ]);
 
-    $this->assertEquals('<p>excerpt</p>', $post->excerpt);
+    expect($post->excerpt)->toEqual('<p>excerpt</p>');
 });
 
 test('a post is tweetable', function () {
     /** @var \App\Models\Post $post */
     $post = Post::factory()->create();
 
-    $this->assertTrue(is_string($post->toTweet()));
+    expect(is_string($post->toTweet()))->toBeTrue();
 });
 
 it('can save the tweeted url', function () {
@@ -100,5 +100,5 @@ it('can save the tweeted url', function () {
 
     $post->onAfterTweet($url);
 
-    $this->assertEquals($url, $post->refresh()->tweet_url);
+    expect($post->refresh()->tweet_url)->toEqual($url);
 });

--- a/tests/Unit/Models/PostTest.php
+++ b/tests/Unit/Models/PostTest.php
@@ -1,121 +1,104 @@
 <?php
 
-namespace Tests\Unit\Models;
-
 use App\Models\Post;
 use Tests\TestCase;
 
-class PostTest extends TestCase
-{
-    /** @test */
-    public function it_can_determine_the_promotional_url()
-    {
-        $post = Post::factory()->create([
-            'title' => 'test',
-        ]);
-        $this->assertEquals(
-            "http://freek.dev.test/{$post->id}-test",
-            $post->promotional_url,
-        );
+uses(TestCase::class);
 
-        $post = Post::factory()->create([
-            'title' => 'test',
-            'external_url' => 'https://external-blog.com/page',
-        ]);
-        $this->assertEquals(
-            'https://external-blog.com/page',
-            $post->promotional_url,
-        );
-    }
+it('can determine the promotional url', function () {
+    $post = Post::factory()->create([
+        'title' => 'test',
+    ]);
+    $this->assertEquals(
+        "http://freek.dev.test/{$post->id}-test",
+        $post->promotional_url,
+    );
 
-    /** @test */
-    public function it_can_get_scheduled_posts()
-    {
-        $this->assertCount(0, Post::scheduled()->get());
+    $post = Post::factory()->create([
+        'title' => 'test',
+        'external_url' => 'https://external-blog.com/page',
+    ]);
+    $this->assertEquals(
+        'https://external-blog.com/page',
+        $post->promotional_url,
+    );
+});
 
-        Post::factory()->create([
-            'publish_date' => now()->subMinute(),
-            'published' => false,
-        ]);
-        $this->assertCount(1, Post::scheduled()->get());
+it('can get scheduled posts', function () {
+    $this->assertCount(0, Post::scheduled()->get());
 
-        Post::factory()->create([
-            'publish_date' => now()->subMinute(),
-            'published' => true,
-        ]);
-        $this->assertCount(1, Post::scheduled()->get());
+    Post::factory()->create([
+        'publish_date' => now()->subMinute(),
+        'published' => false,
+    ]);
+    $this->assertCount(1, Post::scheduled()->get());
 
-        Post::factory()->create([
-            'publish_date' => now()->addMinute(),
-            'published' => false,
-        ]);
-        $this->assertCount(2, Post::scheduled()->get());
+    Post::factory()->create([
+        'publish_date' => now()->subMinute(),
+        'published' => true,
+    ]);
+    $this->assertCount(1, Post::scheduled()->get());
 
-        Post::factory()->create([
-            'publish_date' => null,
-            'published' => false,
-        ]);
-        $this->assertCount(2, Post::scheduled()->get());
-    }
+    Post::factory()->create([
+        'publish_date' => now()->addMinute(),
+        'published' => false,
+    ]);
+    $this->assertCount(2, Post::scheduled()->get());
 
-    /** @test */
-    public function it_can_determine_if_the_post_concerns_a_tweet()
-    {
-        $post = Post::factory()->create();
+    Post::factory()->create([
+        'publish_date' => null,
+        'published' => false,
+    ]);
+    $this->assertCount(2, Post::scheduled()->get());
+});
 
-        $this->assertFalse($post->isTweet());
+it('can determine if the post concerns a tweet', function () {
+    $post = Post::factory()->create();
 
-        $post->syncTags(['php', 'tweet']);
+    $this->assertFalse($post->isTweet());
 
-        $this->assertTrue($post->refresh()->isTweet());
-    }
+    $post->syncTags(['php', 'tweet']);
 
-    /** @test */
-    public function it_can_determine_that_a_post_is_a_tweet()
-    {
-        $post = Post::factory()->create();
-        $this->assertFalse($post->isTweet());
+    $this->assertTrue($post->refresh()->isTweet());
+});
 
-        $post = Post::factory()->create()->attachTag('tweet');
-        $this->assertTrue($post->isTweet());
+it('can determine that a post is a tweet', function () {
+    $post = Post::factory()->create();
+    $this->assertFalse($post->isTweet());
 
-        $post = Post::factory()->create()->attachTags([
-            'tag',
-            'tweet',
-            'another-tag',
-        ]);
-        $this->assertTrue($post->isTweet());
-    }
+    $post = Post::factory()->create()->attachTag('tweet');
+    $this->assertTrue($post->isTweet());
 
-    /** @test */
-    public function it_can_determine_the_excerpt()
-    {
-        $post = Post::factory()->create([
-           'text' => 'excerpt<!--more-->full post',
-        ]);
+    $post = Post::factory()->create()->attachTags([
+        'tag',
+        'tweet',
+        'another-tag',
+    ]);
+    $this->assertTrue($post->isTweet());
+});
 
-        $this->assertEquals('<p>excerpt</p>', $post->excerpt);
-    }
+it('can determine the excerpt', function () {
+    $post = Post::factory()->create([
+       'text' => 'excerpt<!--more-->full post',
+    ]);
 
-    /** @test */
-    public function a_post_is_tweetable()
-    {
-        /** @var \App\Models\Post $post */
-        $post = Post::factory()->create();
+    $this->assertEquals('<p>excerpt</p>', $post->excerpt);
+});
 
-        $this->assertTrue(is_string($post->toTweet()));
-    }
+test('a post is tweetable', function () {
+    /** @var \App\Models\Post $post */
+    $post = Post::factory()->create();
 
-    /** @test */
-    public function it_can_save_the_tweeted_url()
-    {
-        /** @var \App\Models\Post $post */
-        $post = Post::factory()->create();
+    $this->assertTrue(is_string($post->toTweet()));
+});
 
-        $url = 'https://twitter.com/freekmurze/status/123';
+it('can save the tweeted url', function () {
+    /** @var \App\Models\Post $post */
+    $post = Post::factory()->create();
 
-        $post->onAfterTweet($url);
+    $url = 'https://twitter.com/freekmurze/status/123';
 
-        $this->assertEquals($url, $post->refresh()->tweet_url);
-    }
-}
+    $post->onAfterTweet($url);
+
+    $this->assertEquals($url, $post->refresh()->tweet_url);
+});

--- a/tests/Unit/Services/Webmentions/ProcessWebhookJobTest.php
+++ b/tests/Unit/Services/Webmentions/ProcessWebhookJobTest.php
@@ -1,42 +1,38 @@
 <?php
 
-namespace Tests\Unit\Services\Webmentions;
-
 use App\Models\Post;
 use App\Services\Webmentions\ProcessWebhookJob;
 use Spatie\WebhookClient\Models\WebhookCall;
 use Tests\TestCase;
 
-class ProcessWebhookJobTest extends TestCase
+uses(TestCase::class);
+
+it('can convert a webhook payload to a webmention', function () {
+    Post::factory()->create([
+       'id' => 1241,
+    ]);
+
+    $webhookCall = WebhookCall::create([
+        'name' => 'webmentions',
+        'payload' => getStub('payload.json'),
+    ]);
+
+    (new ProcessWebhookJob($webhookCall))->handle();
+
+    $this->assertDatabaseHas('webmentions', [
+        'webmention_id' => '642349',
+        'post_id' => 1241,
+        'type' => 'reply',
+        'author_name' => 'Duy Ha Nguyen',
+        'author_url' => 'https://twitter.com/DuyNguyenHa',
+        'author_photo_url' => 'https://webmention.io/avatar/pbs.twimg.com/ce13341be3d1444d22543bf8601b9c264d1318f6eb46767a77ac5db017bbdebd.png',
+        'interaction_url' => 'https://twitter.com/DuyNguyenHa/status/1147126667162165248',
+        'text' => 'totally agree with you',
+    ]);
+});
+
+// Helpers
+function getStub(string $name): array
 {
-    /** @test */
-    public function it_can_convert_a_webhook_payload_to_a_webmention()
-    {
-        Post::factory()->create([
-           'id' => 1241,
-        ]);
-
-        $webhookCall = WebhookCall::create([
-            'name' => 'webmentions',
-            'payload' => $this->getStub('payload.json'),
-        ]);
-
-        (new ProcessWebhookJob($webhookCall))->handle();
-
-        $this->assertDatabaseHas('webmentions', [
-            'webmention_id' => '642349',
-            'post_id' => 1241,
-            'type' => 'reply',
-            'author_name' => 'Duy Ha Nguyen',
-            'author_url' => 'https://twitter.com/DuyNguyenHa',
-            'author_photo_url' => 'https://webmention.io/avatar/pbs.twimg.com/ce13341be3d1444d22543bf8601b9c264d1318f6eb46767a77ac5db017bbdebd.png',
-            'interaction_url' => 'https://twitter.com/DuyNguyenHa/status/1147126667162165248',
-            'text' => 'totally agree with you',
-        ]);
-    }
-
-    private function getStub(string $name): array
-    {
-        return json_decode(file_get_contents(__DIR__ . "/stubs/{$name}"), true);
-    }
+    return json_decode(file_get_contents(__DIR__ . "/stubs/{$name}"), true);
 }


### PR DESCRIPTION
This pull request contains changes for migrating your test suite from PHPUnit to [Pest](https://pestphp.com/) automated by the [Pest Converter](https://laravelshift.com/phpunit-to-pest-converter).

**Before merging**, you need to:

- Checkout the `shift-49066` branch
- Review **all** of the comments below for additional changes
- Run `composer update` to install Pest with your dependencies
- Run `vendor/bin/pest` to verify the conversion
