### PR TITLE
Adds honeypot field to the newsletter form

### DIFF
--- a/resources/views/front/newsletter/partials/form.blade.php
+++ b/resources/views/front/newsletter/partials/form.blade.php
@@ -4,7 +4,8 @@
     accept-charset="utf-8"
     class="flex flex-col md:flex-row items-stretch {{ $class ?? '' }}"
 >
-    @csrf
+    <input type="text" name="username" style="display:none !important" tabindex="-1" autocomplete="off">
+
     <input class="mb-2 md:mb-0" type="email" autocomplete="off" id="email" name="email" placeholder="Your e-mail address" aria-label="E-mail" required>
 
     <input type="submit" name="submit" id="submit" value="Subscribe" class="px-3 py-2 text-sm text-white bg-yellow-500 font-semibold border-t-3 border-b-3 border-yellow-700 border-t-transparent">


### PR DESCRIPTION
`@csrf` is not necessary as the form submission is now external to Mailcoach Cloud